### PR TITLE
Restrict admin user creation to existing sections

### DIFF
--- a/client/src/components/AddUserDialog.tsx
+++ b/client/src/components/AddUserDialog.tsx
@@ -8,7 +8,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { userRoles } from "@shared/schema";
 
 const addUserSchema = z.object({
@@ -29,6 +29,11 @@ interface AddUserDialogProps {
 export default function AddUserDialog({ open, onClose }: AddUserDialogProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+
+  const { data: sections = [] } = useQuery<string[]>({
+    queryKey: ["/api/auth/sections"],
+    enabled: open,
+  });
 
   const form = useForm<AddUserFormData>({
     resolver: zodResolver(addUserSchema),
@@ -89,7 +94,16 @@ export default function AddUserDialog({ open, onClose }: AddUserDialogProps) {
                 <FormItem>
                   <FormLabel>القسم</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder="القسم" />
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="اختر القسم" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {sections.map((section) => (
+                          <SelectItem key={section} value={section}>{section}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## Summary
- Replace the free-text section/group input in the admin Add User dialog with a Select populated from `/api/auth/sections`, so admins can only assign new users to existing groups.

## Why
Previously the admin "Create New User" form let admins type any value into the section field, which silently created a new group whenever they made a typo or invented a name. The dropdown ensures consistency with the groups already in use.

## Test plan
- [ ] As an admin, open the Add User dialog and confirm the "القسم" field is a dropdown listing the existing sections returned by `/api/auth/sections`.
- [ ] Confirm submitting without selecting a section shows the validation error.
- [ ] Create a user against an existing section and verify they appear under that section on login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)