### PR TITLE
Add weekly scheduling board for recurring journey slots

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { Navigation } from "@/components/Navigation";
 import { RealTimeProvider } from "@/contexts/RealTimeContext";
 import { LoginForm } from "@/components/LoginForm";
 import Dashboard from "@/pages/Dashboard";
+import SchedulePage from "@/pages/SchedulePage";
 
 import AdminDashboard from "@/pages/AdminDashboard";
 import DriverDashboard from "@/pages/DriverDashboard";
@@ -40,6 +41,15 @@ function Router() {
       ) : (
         <>
           <Route path="/" component={() => (
+            <div className="min-h-screen bg-background">
+              <Navigation />
+              <div className="px-3 sm:px-0">
+                <SchedulePage />
+              </div>
+            </div>
+          )} />
+
+          <Route path="/dashboard" component={() => (
             <div className="min-h-screen bg-background">
               <Navigation />
               <div className="px-3 sm:px-0">

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { Bell, Car, MessageSquare, Home, Users, Settings, UserCheck, User } from "lucide-react";
+import { Bell, Car, MessageSquare, Home, Users, Settings, UserCheck, User, Calendar } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation } from "wouter";
 import { RealTimeStatus } from "@/components/RealTimeStatus";
@@ -44,9 +44,15 @@ export function Navigation() {
   const navItems = [
     {
       href: "/",
+      label: "الجدول",
+      icon: Calendar,
+      active: location === "/",
+    },
+    {
+      href: "/dashboard",
       label: "لوحة التحكم",
       icon: Home,
-      active: location === "/",
+      active: location === "/dashboard",
     },
     {
       href: "/profile",

--- a/client/src/components/SlotDetailsDialog.tsx
+++ b/client/src/components/SlotDetailsDialog.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { formatGMTPlus3TimeOnly, toGMTPlus3 } from "@shared/timezone";
+import { MapPin, Clock, Users, Trash2, Repeat } from "lucide-react";
+
+export interface SlotWithMeta {
+  id: number;
+  seriesId: string | null;
+  destination: string;
+  startTime: string;
+  endTime: string;
+  driversNeeded: number;
+  notes: string | null;
+  registeredCount: number;
+  isRegistered: boolean;
+}
+
+interface SlotDetailsDialogProps {
+  slot: SlotWithMeta | null;
+  onClose: () => void;
+  isAdmin: boolean;
+}
+
+function formatDayLabel(iso: string): string {
+  const g = toGMTPlus3(new Date(iso));
+  const days = ["الأحد", "الإثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت"];
+  return `${days[g.getUTCDay()]} ${g.getUTCDate()}/${g.getUTCMonth() + 1}`;
+}
+
+export function SlotDetailsDialog({ slot, onClose, isAdmin }: SlotDetailsDialogProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [alert, setAlert] = useState<"register" | "unregister" | "delete" | null>(null);
+
+  const open = !!slot;
+  const isSeries = !!slot?.seriesId;
+
+  const { data: registrations = [] } = useQuery<any[]>({
+    queryKey: ["/api/schedule/slots", slot?.id, "registrations"],
+    queryFn: async () => {
+      const res = await fetch(`/api/schedule/slots/${slot!.id}/registrations`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to load registrations");
+      return res.json();
+    },
+    enabled: open,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["/api/schedule/slots"] });
+  };
+
+  const registerMutation = useMutation({
+    mutationFn: (repeatWeekly: boolean) =>
+      apiRequest("POST", `/api/schedule/slots/${slot!.id}/register`, { repeatWeekly }),
+    onSuccess: () => {
+      toast({ title: "تم التسجيل" });
+      invalidate();
+      onClose();
+    },
+    onError: (e: any) =>
+      toast({ title: "خطأ", description: e.message, variant: "destructive" }),
+  });
+
+  const unregisterMutation = useMutation({
+    mutationFn: (scope: "single" | "series") =>
+      apiRequest("DELETE", `/api/schedule/slots/${slot!.id}/register`, { scope }),
+    onSuccess: () => {
+      toast({ title: "تم إلغاء التسجيل" });
+      invalidate();
+      onClose();
+    },
+    onError: (e: any) =>
+      toast({ title: "خطأ", description: e.message, variant: "destructive" }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (scope: "single" | "series") =>
+      apiRequest("DELETE", `/api/schedule/slots/${slot!.id}?scope=${scope}`),
+    onSuccess: () => {
+      toast({ title: "تم الحذف" });
+      invalidate();
+      onClose();
+    },
+    onError: (e: any) =>
+      toast({ title: "خطأ", description: e.message, variant: "destructive" }),
+  });
+
+  if (!slot) return null;
+
+  const met = slot.registeredCount >= slot.driversNeeded;
+
+  // Register: confirm "repeat weekly?" only for recurring slots; otherwise just do it.
+  const handleRegisterClick = () => {
+    if (isSeries) setAlert("register");
+    else registerMutation.mutate(false);
+  };
+  const handleUnregisterClick = () => {
+    if (isSeries) setAlert("unregister");
+    else unregisterMutation.mutate("single");
+  };
+  const handleDeleteClick = () => {
+    if (isSeries) setAlert("delete");
+    else deleteMutation.mutate("single");
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <MapPin className="h-4 w-4" />
+              {slot.destination}
+              {isSeries && <Repeat className="h-4 w-4 text-muted-foreground" />}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-3 text-sm">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Clock className="h-4 w-4" />
+              {formatDayLabel(slot.startTime)} · {formatGMTPlus3TimeOnly(new Date(slot.startTime))}
+              {" - "}
+              {formatGMTPlus3TimeOnly(new Date(slot.endTime))}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              <Badge variant={met ? "default" : "destructive"}>
+                {slot.registeredCount} / {slot.driversNeeded} سائق
+              </Badge>
+              {!met && (
+                <span className="text-muted-foreground">
+                  المتبقي: {slot.driversNeeded - slot.registeredCount}
+                </span>
+              )}
+            </div>
+
+            {slot.notes && <p className="text-muted-foreground">{slot.notes}</p>}
+
+            <div>
+              <p className="mb-1 font-medium">السائقون المسجلون</p>
+              {registrations.length === 0 ? (
+                <p className="text-muted-foreground">لا يوجد سائقون بعد</p>
+              ) : (
+                <ul className="space-y-1">
+                  {registrations.map((r) => (
+                    <li key={r.id} className="flex justify-between rounded bg-muted px-2 py-1">
+                      <span>{r.username}</span>
+                      <span className="text-muted-foreground">{r.section}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex flex-wrap justify-end gap-2 pt-2">
+              {slot.isRegistered ? (
+                <Button
+                  variant="outline"
+                  onClick={handleUnregisterClick}
+                  disabled={unregisterMutation.isPending}
+                >
+                  إلغاء تسجيلي
+                </Button>
+              ) : (
+                <Button onClick={handleRegisterClick} disabled={registerMutation.isPending}>
+                  سجّلني كسائق
+                </Button>
+              )}
+              {isAdmin && (
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteClick}
+                  disabled={deleteMutation.isPending}
+                >
+                  <Trash2 className="ml-1 h-4 w-4" />
+                  حذف
+                </Button>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Register: repeat weekly? */}
+      <AlertDialog open={alert === "register"} onOpenChange={(o) => !o && setAlert(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>تسجيل متكرر</AlertDialogTitle>
+            <AlertDialogDescription>
+              هل تريد تسجيل نفسك في هذا الموعد كل أسبوع حتى نهاية التكرار؟
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-wrap gap-2">
+            <AlertDialogCancel>إلغاء</AlertDialogCancel>
+            <AlertDialogAction onClick={() => registerMutation.mutate(false)}>
+              هذا الموعد فقط
+            </AlertDialogAction>
+            <AlertDialogAction onClick={() => registerMutation.mutate(true)}>
+              نعم، كرر أسبوعياً
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Unregister: single or whole series */}
+      <AlertDialog open={alert === "unregister"} onOpenChange={(o) => !o && setAlert(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>إلغاء التسجيل</AlertDialogTitle>
+            <AlertDialogDescription>
+              هل تريد إلغاء تسجيلك من هذا الموعد فقط أم من جميع المواعيد القادمة؟
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-wrap gap-2">
+            <AlertDialogCancel>تراجع</AlertDialogCancel>
+            <AlertDialogAction onClick={() => unregisterMutation.mutate("single")}>
+              هذا الموعد فقط
+            </AlertDialogAction>
+            <AlertDialogAction onClick={() => unregisterMutation.mutate("series")}>
+              كل المواعيد القادمة
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete (admin): single or whole series */}
+      <AlertDialog open={alert === "delete"} onOpenChange={(o) => !o && setAlert(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>حذف الموعد</AlertDialogTitle>
+            <AlertDialogDescription>
+              هل تريد حذف هذا الموعد فقط أم هذا الموعد وجميع المواعيد القادمة في السلسلة؟
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-wrap gap-2">
+            <AlertDialogCancel>تراجع</AlertDialogCancel>
+            <AlertDialogAction onClick={() => deleteMutation.mutate("single")}>
+              هذا الموعد فقط
+            </AlertDialogAction>
+            <AlertDialogAction onClick={() => deleteMutation.mutate("series")}>
+              هذا وكل القادم
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/client/src/components/SlotFormDialog.tsx
+++ b/client/src/components/SlotFormDialog.tsx
@@ -1,0 +1,331 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+// 0 = Sunday .. 6 = Saturday (matches the server's daysOfWeek convention).
+const WEEKDAYS = [
+  { value: 0, label: "الأحد" },
+  { value: 1, label: "الإثنين" },
+  { value: 2, label: "الثلاثاء" },
+  { value: 3, label: "الأربعاء" },
+  { value: 4, label: "الخميس" },
+  { value: 5, label: "الجمعة" },
+  { value: 6, label: "السبت" },
+];
+
+const DURATIONS = [
+  { value: 30, label: "30 دقيقة" },
+  { value: 60, label: "ساعة" },
+  { value: 90, label: "ساعة ونصف" },
+  { value: 120, label: "ساعتان" },
+  { value: 180, label: "3 ساعات" },
+  { value: 240, label: "4 ساعات" },
+];
+
+const formSchema = z
+  .object({
+    destination: z.string().min(1, "الوجهة مطلوبة"),
+    startTime: z.string().min(1, "الوقت مطلوب"),
+    durationMinutes: z.number().min(15),
+    driversNeeded: z.number().min(1, "سائق واحد على الأقل"),
+    notes: z.string().optional(),
+    isRecurring: z.boolean().default(false),
+    daysOfWeek: z.array(z.number()).default([]),
+    endDate: z.string().optional(),
+  })
+  .refine((d) => !d.isRecurring || d.daysOfWeek.length > 0, {
+    message: "اختر يوماً واحداً على الأقل",
+    path: ["daysOfWeek"],
+  })
+  .refine((d) => !d.isRecurring || !!d.endDate, {
+    message: "تاريخ الانتهاء مطلوب",
+    path: ["endDate"],
+  });
+
+type FormData = z.infer<typeof formSchema>;
+
+interface SlotFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Prefilled GMT+3 wall-clock start time, e.g. "2026-06-10T13:00". */
+  defaultStart?: string;
+}
+
+export function SlotFormDialog({ open, onClose, defaultStart }: SlotFormDialogProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      destination: "",
+      startTime: defaultStart || "",
+      durationMinutes: 60,
+      driversNeeded: 1,
+      notes: "",
+      isRecurring: false,
+      daysOfWeek: defaultStart ? [new Date(defaultStart).getDay()] : [],
+      endDate: "",
+    },
+  });
+
+  // Re-seed the form whenever the dialog opens from a fresh calendar click.
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        destination: "",
+        startTime: defaultStart || "",
+        durationMinutes: 60,
+        driversNeeded: 1,
+        notes: "",
+        isRecurring: false,
+        daysOfWeek: defaultStart ? [new Date(defaultStart).getDay()] : [],
+        endDate: "",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, defaultStart]);
+
+  const isRecurring = form.watch("isRecurring");
+
+  const createMutation = useMutation({
+    mutationFn: async (data: FormData) => {
+      const payload: any = {
+        destination: data.destination,
+        startTime: data.startTime,
+        durationMinutes: data.durationMinutes,
+        driversNeeded: data.driversNeeded,
+        notes: data.notes || undefined,
+      };
+      if (data.isRecurring && data.endDate) {
+        payload.recurrence = {
+          daysOfWeek: data.daysOfWeek,
+          endDate: data.endDate,
+        };
+      }
+      return apiRequest("POST", "/api/schedule/slots", payload);
+    },
+    onSuccess: async (res) => {
+      const result = await res.json();
+      toast({
+        title: "تم إنشاء الموعد",
+        description: `تم إنشاء ${result.created} موعد`,
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/schedule/slots"] });
+      onClose();
+    },
+    onError: (error: any) => {
+      toast({
+        title: "خطأ",
+        description: error.message || "فشل إنشاء الموعد",
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>إضافة موعد جديد</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((d) => createMutation.mutate(d))}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="destination"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>الوجهة</FormLabel>
+                  <FormControl>
+                    <Input placeholder="مثال: النادي" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="startTime"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>وقت البداية</FormLabel>
+                  <FormControl>
+                    <Input type="datetime-local" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="durationMinutes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>المدة</FormLabel>
+                  <Select
+                    value={String(field.value)}
+                    onValueChange={(v) => field.onChange(Number(v))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {DURATIONS.map((d) => (
+                        <SelectItem key={d.value} value={String(d.value)}>
+                          {d.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="driversNeeded"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>عدد السائقين المطلوبين</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      {...field}
+                      onChange={(e) => field.onChange(Number(e.target.value))}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isRecurring"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                  <FormLabel className="!mt-0">تكرار أسبوعي</FormLabel>
+                </FormItem>
+              )}
+            />
+
+            {isRecurring && (
+              <div className="space-y-3 rounded-md border p-3">
+                <FormField
+                  control={form.control}
+                  name="daysOfWeek"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>أيام التكرار</FormLabel>
+                      <div className="flex flex-wrap gap-2">
+                        {WEEKDAYS.map((day) => {
+                          const checked = field.value?.includes(day.value);
+                          return (
+                            <Label
+                              key={day.value}
+                              className={`flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-sm ${
+                                checked ? "bg-primary text-primary-foreground" : ""
+                              }`}
+                            >
+                              <Checkbox
+                                className="hidden"
+                                checked={checked}
+                                onCheckedChange={(c) => {
+                                  const set = new Set(field.value || []);
+                                  if (c) set.add(day.value);
+                                  else set.delete(day.value);
+                                  field.onChange(Array.from(set).sort());
+                                }}
+                              />
+                              {day.label}
+                            </Label>
+                          );
+                        })}
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="endDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>يتكرر حتى</FormLabel>
+                      <FormControl>
+                        <Input type="date" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ملاحظات (اختياري)</FormLabel>
+                  <FormControl>
+                    <Textarea rows={2} {...field} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={onClose}>
+                إلغاء
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending ? "جاري الحفظ..." : "حفظ"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/contexts/RealTimeContext.tsx
+++ b/client/src/contexts/RealTimeContext.tsx
@@ -171,6 +171,13 @@ export function RealTimeProvider({ children }: RealTimeProviderProps) {
         queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
         break;
 
+      case "slot_created":
+      case "slot_deleted":
+      case "slot_registration_changed":
+        // Refresh the scheduling board so counts update live for everyone.
+        queryClient.invalidateQueries({ queryKey: ["/api/schedule/slots"] });
+        break;
+
       default:
         console.log("Unknown real-time message type:", message.type);
     }

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { nowGMTPlus3, toGMTPlus3, formatGMTPlus3TimeOnly } from "@shared/timezone";
+import { SlotFormDialog } from "@/components/SlotFormDialog";
+import { SlotDetailsDialog, type SlotWithMeta } from "@/components/SlotDetailsDialog";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_PX = 56;
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const WEEKDAY_LABELS = ["الأحد", "الإثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت"];
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+// Wall-clock (GMT+3) ms for the Sunday that starts the week containing `date`.
+function weekStartOf(date: Date): number {
+  const g = toGMTPlus3(date);
+  const dayMidnight = Date.UTC(g.getUTCFullYear(), g.getUTCMonth(), g.getUTCDate());
+  return dayMidnight - g.getUTCDay() * DAY_MS;
+}
+
+function ymd(wallMs: number): string {
+  const d = new Date(wallMs);
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+export default function SchedulePage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
+  const [weekStart, setWeekStart] = useState<number>(() => weekStartOf(nowGMTPlus3()));
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createDefault, setCreateDefault] = useState<string | undefined>();
+  const [selectedSlot, setSelectedSlot] = useState<SlotWithMeta | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const weekStartStr = ymd(weekStart);
+
+  const { data: slots = [] } = useQuery<SlotWithMeta[]>({
+    queryKey: ["/api/schedule/slots", weekStartStr],
+    queryFn: async () => {
+      const res = await fetch(`/api/schedule/slots?weekStart=${weekStartStr}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to load slots");
+      return res.json();
+    },
+    enabled: !!user,
+  });
+
+  // Start the week view scrolled to the morning rather than midnight.
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 7 * HOUR_PX;
+  }, []);
+
+  const days = useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, i) => {
+        const wallMs = weekStart + i * DAY_MS;
+        const d = new Date(wallMs);
+        return {
+          index: i,
+          wallMs,
+          label: WEEKDAY_LABELS[d.getUTCDay()],
+          dateNum: d.getUTCDate(),
+          month: d.getUTCMonth() + 1,
+        };
+      }),
+    [weekStart],
+  );
+
+  const todayWallMidnight = useMemo(() => {
+    const g = nowGMTPlus3();
+    return Date.UTC(g.getUTCFullYear(), g.getUTCMonth(), g.getUTCDate());
+  }, []);
+
+  // Group slots into their day column with computed top/height.
+  const positioned = useMemo(() => {
+    return slots.map((slot) => {
+      const g = toGMTPlus3(new Date(slot.startTime));
+      const slotDayWall = Date.UTC(g.getUTCFullYear(), g.getUTCMonth(), g.getUTCDate());
+      const dayIndex = Math.round((slotDayWall - weekStart) / DAY_MS);
+      const startHour = g.getUTCHours() + g.getUTCMinutes() / 60;
+      const durationHours =
+        (new Date(slot.endTime).getTime() - new Date(slot.startTime).getTime()) / 3_600_000;
+      return {
+        slot,
+        dayIndex,
+        top: startHour * HOUR_PX,
+        height: Math.max(durationHours * HOUR_PX, 26),
+      };
+    });
+  }, [slots, weekStart]);
+
+  const handleCellClick = (dayWallMs: number, hour: number) => {
+    if (!isAdmin) return;
+    const d = new Date(dayWallMs);
+    const start = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(
+      d.getUTCDate(),
+    )}T${pad(hour)}:00`;
+    setCreateDefault(start);
+    setCreateOpen(true);
+  };
+
+  const monthLabel = `${days[0].dateNum}/${days[0].month} - ${days[6].dateNum}/${days[6].month}`;
+
+  return (
+    <div className="mobile-container py-3 sm:py-6">
+      {/* Header */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <h1 className="text-xl font-bold">جدول الرحلات</h1>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setWeekStart((w) => w - 7 * DAY_MS)}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setWeekStart(weekStartOf(nowGMTPlus3()))}
+          >
+            هذا الأسبوع
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setWeekStart((w) => w + 7 * DAY_MS)}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">{monthLabel}</span>
+          {isAdmin && (
+            <Button
+              size="sm"
+              onClick={() => {
+                setCreateDefault(undefined);
+                setCreateOpen(true);
+              }}
+            >
+              <Plus className="ml-1 h-4 w-4" /> موعد
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Card className="overflow-hidden">
+        <div dir="ltr">
+          {/* Sticky day header */}
+          <div className="flex border-b bg-background">
+            <div className="w-14 shrink-0" />
+            {days.map((day) => {
+              const isToday = day.wallMs === todayWallMidnight;
+              return (
+                <div
+                  key={day.index}
+                  className={`flex-1 border-l py-2 text-center ${
+                    isToday ? "bg-primary/10" : ""
+                  }`}
+                >
+                  <div className="text-xs text-muted-foreground">{day.label}</div>
+                  <div className={`text-sm font-semibold ${isToday ? "text-primary" : ""}`}>
+                    {day.dateNum}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Scrollable timed grid */}
+          <div ref={scrollRef} className="max-h-[70vh] overflow-y-auto">
+            <div className="flex">
+              {/* Time gutter */}
+              <div className="w-14 shrink-0">
+                {HOURS.map((h) => (
+                  <div
+                    key={h}
+                    className="relative border-b text-[10px] text-muted-foreground"
+                    style={{ height: HOUR_PX }}
+                  >
+                    <span className="absolute -top-2 right-1">{formatHour(h)}</span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Day columns */}
+              {days.map((day) => (
+                <div key={day.index} className="relative flex-1 border-l">
+                  {HOURS.map((h) => (
+                    <div
+                      key={h}
+                      className={`border-b ${isAdmin ? "cursor-pointer hover:bg-accent/40" : ""}`}
+                      style={{ height: HOUR_PX }}
+                      onClick={() => handleCellClick(day.wallMs, h)}
+                    />
+                  ))}
+
+                  {/* Events for this day */}
+                  {positioned
+                    .filter((p) => p.dayIndex === day.index)
+                    .map((p) => {
+                      const met = p.slot.registeredCount >= p.slot.driversNeeded;
+                      return (
+                        <button
+                          key={p.slot.id}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setSelectedSlot(p.slot);
+                          }}
+                          className={`absolute inset-x-0.5 overflow-hidden rounded px-1 py-0.5 text-right text-[11px] text-white shadow-sm ${
+                            met ? "bg-green-600 hover:bg-green-700" : "bg-rose-600 hover:bg-rose-700"
+                          }`}
+                          style={{ top: p.top, height: p.height }}
+                        >
+                          <div className="truncate font-medium">{p.slot.destination}</div>
+                          <div className="truncate opacity-90">
+                            {formatGMTPlus3TimeOnly(new Date(p.slot.startTime))} ·{" "}
+                            {p.slot.registeredCount}/{p.slot.driversNeeded}
+                          </div>
+                        </button>
+                      );
+                    })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <SlotFormDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        defaultStart={createDefault}
+      />
+      <SlotDetailsDialog
+        slot={selectedSlot}
+        onClose={() => setSelectedSlot(null)}
+        isAdmin={isAdmin}
+      />
+    </div>
+  );
+}
+
+function formatHour(h: number): string {
+  const ampm = h >= 12 ? "م" : "ص";
+  const display = h % 12 || 12;
+  return `${display} ${ampm}`;
+}

--- a/server/new-routes.ts
+++ b/server/new-routes.ts
@@ -12,6 +12,8 @@ import {
   insertRideRequestSchema,
   insertTripParticipantSchema,
   insertTripJoinRequestSchema,
+  createSlotRequestSchema,
+  type CreateSlotRequest,
 } from "@shared/schema";
 import { z } from "zod";
 import TelegramBot from "node-telegram-bot-api";
@@ -19,6 +21,7 @@ import {
   formatGMTPlus3,
   formatGMTPlus3TimeOnly,
   formatDateForInput,
+  GMT_PLUS_3_OFFSET,
 } from "@shared/timezone";
 import { nanoid } from "nanoid";
 import { hashPassword } from "./auth-utils";
@@ -38,6 +41,62 @@ function broadcastToAll(data: any) {
       ws.send(message);
     }
   });
+}
+
+// ===================== Schedule slot helpers =====================
+// All slot times are entered as GMT+3 wall-clock and stored as UTC. GMT+3 has a
+// fixed offset (no DST), so we can do plain ms arithmetic on day boundaries.
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_OCCURRENCES = 366; // safety bound on a single recurring series
+
+// Parse a "YYYY-MM-DDTHH:mm" GMT+3 wall-clock string into its numeric parts.
+function parseWall(wall: string): { y: number; mo: number; d: number; h: number; mi: number } {
+  const [datePart, timePart = "00:00"] = wall.split("T");
+  const [y, mo, d] = datePart.split("-").map(Number);
+  const [h, mi] = timePart.split(":").map(Number);
+  return { y, mo, d, h, mi };
+}
+
+// Expand a create-slot request into concrete occurrences (UTC start/end Dates).
+function expandOccurrences(reqData: CreateSlotRequest): { startTime: Date; endTime: Date }[] {
+  const { startTime, durationMinutes, recurrence } = reqData;
+  const base = parseWall(startTime);
+  const durMs = durationMinutes * 60 * 1000;
+  // A UTC instant whose UTC fields equal the GMT+3 wall clock, minus the offset.
+  const toUTC = (wallMs: number) => new Date(wallMs - GMT_PLUS_3_OFFSET);
+
+  if (!recurrence) {
+    const start = toUTC(Date.UTC(base.y, base.mo - 1, base.d, base.h, base.mi));
+    return [{ startTime: start, endTime: new Date(start.getTime() + durMs) }];
+  }
+
+  const days = new Set(recurrence.daysOfWeek);
+  const end = parseWall(recurrence.endDate);
+  const endWallMs = Date.UTC(end.y, end.mo - 1, end.d, 23, 59); // inclusive of end date
+  const occurrences: { startTime: Date; endTime: Date }[] = [];
+
+  // Iterate day-by-day from the start date forward, keeping the wall-clock time.
+  let cursor = Date.UTC(base.y, base.mo - 1, base.d, base.h, base.mi);
+  let guard = 0;
+  while (cursor <= endWallMs && guard < MAX_OCCURRENCES) {
+    const weekday = new Date(cursor).getUTCDay(); // weekday of the GMT+3 wall date
+    if (days.has(weekday)) {
+      const start = toUTC(cursor);
+      occurrences.push({ startTime: start, endTime: new Date(start.getTime() + durMs) });
+    }
+    cursor += DAY_MS;
+    guard++;
+  }
+  return occurrences;
+}
+
+// Compute the UTC range [start, end) for a GMT+3 week beginning on the given
+// "YYYY-MM-DD" Sunday.
+function weekRangeUTC(weekStart: string): { start: Date; end: Date } {
+  const { y, mo, d } = parseWall(weekStart);
+  const start = new Date(Date.UTC(y, mo - 1, d, 0, 0) - GMT_PLUS_3_OFFSET);
+  const end = new Date(start.getTime() + 7 * DAY_MS);
+  return { start, end };
 }
 
 function setupWebSocket(server: Server) {
@@ -1345,6 +1404,152 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       console.error("Error updating trip:", error);
       res.status(500).json({ message: "Failed to update trip" });
+    }
+  });
+  // =====================================================================
+
+  // ===================== Scheduling board (slots) =====================
+  // Weekly view data: all slots in a GMT+3 week, with registration counts and
+  // whether the current user is registered.
+  app.get("/api/schedule/slots", isAuthenticated, async (req: any, res) => {
+    try {
+      const weekStart = String(req.query.weekStart || "");
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(weekStart)) {
+        return res.status(400).json({ message: "weekStart (YYYY-MM-DD) is required" });
+      }
+      const { start, end } = weekRangeUTC(weekStart);
+      const slots = await storage.getSlotsBetween(start, end);
+      const ids = slots.map((s) => s.id);
+      const counts = await storage.getSlotRegistrationCounts(ids);
+      const registered = await storage.getUserRegisteredSlotIds(ids, req.user.id);
+
+      res.json(
+        slots.map((slot) => ({
+          ...slot,
+          registeredCount: counts.get(slot.id) || 0,
+          isRegistered: registered.has(slot.id),
+        })),
+      );
+    } catch (error) {
+      console.error("Error fetching schedule slots:", error);
+      res.status(500).json({ message: "Failed to fetch schedule slots" });
+    }
+  });
+
+  // Admin creates a slot (optionally recurring), expanded into occurrence rows.
+  app.post("/api/schedule/slots", isAuthenticated, isAdmin, async (req: any, res) => {
+    try {
+      const data = createSlotRequestSchema.parse(req.body);
+      const occurrences = expandOccurrences(data);
+      if (occurrences.length === 0) {
+        return res.status(400).json({ message: "No occurrences generated for this slot" });
+      }
+
+      const seriesId = data.recurrence ? `slot_${nanoid()}` : null;
+      const rows = occurrences.map((occ) => ({
+        seriesId,
+        destination: data.destination,
+        startTime: occ.startTime,
+        endTime: occ.endTime,
+        driversNeeded: data.driversNeeded,
+        notes: data.notes || null,
+        createdBy: req.user.id,
+      }));
+
+      const created = await storage.createSlots(rows);
+
+      broadcastToAll({ type: "slot_created", count: created.length });
+      res.status(201).json({ created: created.length, seriesId });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: "Invalid slot data", errors: error.errors });
+      }
+      console.error("Error creating schedule slot:", error);
+      res.status(500).json({ message: "Failed to create schedule slot" });
+    }
+  });
+
+  // Admin deletes a slot — either this single occurrence or this + future ones.
+  app.delete("/api/schedule/slots/:id", isAuthenticated, isAdmin, async (req: any, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      const scope = req.query.scope === "series" ? "series" : "single";
+      const slot = await storage.getSlot(id);
+      if (!slot) return res.status(404).json({ message: "Slot not found" });
+
+      if (scope === "series" && slot.seriesId) {
+        await storage.deleteSeriesFrom(slot.seriesId, slot.startTime);
+      } else {
+        await storage.deleteSlot(id);
+      }
+
+      broadcastToAll({ type: "slot_deleted", id });
+      res.json({ success: true });
+    } catch (error) {
+      console.error("Error deleting schedule slot:", error);
+      res.status(500).json({ message: "Failed to delete schedule slot" });
+    }
+  });
+
+  // List the drivers registered for a slot (for the details dialog).
+  app.get("/api/schedule/slots/:id/registrations", isAuthenticated, async (req: any, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      const registrations = await storage.getSlotRegistrations(id);
+      res.json(registrations);
+    } catch (error) {
+      console.error("Error fetching slot registrations:", error);
+      res.status(500).json({ message: "Failed to fetch registrations" });
+    }
+  });
+
+  // Current user registers as a driver for a slot (optionally the whole series).
+  app.post("/api/schedule/slots/:id/register", isAuthenticated, async (req: any, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      const repeatWeekly = req.body?.repeatWeekly === true;
+      const slot = await storage.getSlot(id);
+      if (!slot) return res.status(404).json({ message: "Slot not found" });
+
+      if (repeatWeekly && slot.seriesId) {
+        const futureSlots = await storage.getFutureSlotsInSeries(slot.seriesId, slot.startTime);
+        for (const s of futureSlots) {
+          await storage.registerForSlot(s.id, req.user.id);
+        }
+      } else {
+        await storage.registerForSlot(id, req.user.id);
+      }
+
+      broadcastToAll({ type: "slot_registration_changed", id });
+      res.json({ success: true });
+    } catch (error) {
+      console.error("Error registering for slot:", error);
+      res.status(500).json({ message: "Failed to register for slot" });
+    }
+  });
+
+  // Current user unregisters from a slot (optionally the whole future series).
+  app.delete("/api/schedule/slots/:id/register", isAuthenticated, async (req: any, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      const scope = req.body?.scope === "series" ? "series" : "single";
+      const slot = await storage.getSlot(id);
+      if (!slot) return res.status(404).json({ message: "Slot not found" });
+
+      if (scope === "series" && slot.seriesId) {
+        const futureSlots = await storage.getFutureSlotsInSeries(slot.seriesId, slot.startTime);
+        for (const s of futureSlots) {
+          await storage.unregisterFromSlot(s.id, req.user.id);
+        }
+      } else {
+        await storage.unregisterFromSlot(id, req.user.id);
+      }
+
+      broadcastToAll({ type: "slot_registration_changed", id });
+      res.json({ success: true });
+    } catch (error) {
+      console.error("Error unregistering from slot:", error);
+      res.status(500).json({ message: "Failed to unregister from slot" });
     }
   });
   // =====================================================================

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,6 +5,8 @@ import {
   tripParticipants,
   tripJoinRequests,
   notifications,
+  scheduleSlots,
+  slotRegistrations,
   type User,
   type InsertUser,
   type Trip,
@@ -18,9 +20,12 @@ import {
   type Notification,
   type InsertNotification,
   type UserRole,
+  type ScheduleSlot,
+  type InsertScheduleSlot,
+  type SlotRegistration,
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, and, gte, lt } from "drizzle-orm";
+import { eq, and, gte, lt, inArray, sql } from "drizzle-orm";
 import { nowGMTPlus3, getTodayRangeUTC, fromGMTPlus3ToUTC } from "@shared/timezone";
 
 export interface IStorage {
@@ -75,6 +80,19 @@ export interface IStorage {
   createNotification(notification: InsertNotification): Promise<Notification>;
   getUserNotifications(userId: string): Promise<Notification[]>;
   markNotificationAsRead(id: number): Promise<void>;
+
+  // Schedule slot operations
+  createSlots(rows: InsertScheduleSlot[]): Promise<ScheduleSlot[]>;
+  getSlot(id: number): Promise<ScheduleSlot | undefined>;
+  getSlotsBetween(start: Date, end: Date): Promise<ScheduleSlot[]>;
+  deleteSlot(id: number): Promise<void>;
+  deleteSeriesFrom(seriesId: string, fromTime: Date): Promise<void>;
+  getFutureSlotsInSeries(seriesId: string, fromTime: Date): Promise<ScheduleSlot[]>;
+  getSlotRegistrationCounts(slotIds: number[]): Promise<Map<number, number>>;
+  getUserRegisteredSlotIds(slotIds: number[], userId: string): Promise<Set<number>>;
+  getSlotRegistrations(slotId: number): Promise<(SlotRegistration & { username: string; section: string; phoneNumber: string | null })[]>;
+  registerForSlot(slotId: number, driverId: string): Promise<void>;
+  unregisterFromSlot(slotId: number, driverId: string): Promise<void>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -628,6 +646,106 @@ export class DatabaseStorage implements IStorage {
       .update(notifications)
       .set({ isRead: true })
       .where(eq(notifications.id, id));
+  }
+
+  // ===================== Schedule slot operations =====================
+  async createSlots(rows: InsertScheduleSlot[]): Promise<ScheduleSlot[]> {
+    if (rows.length === 0) return [];
+    return await db.insert(scheduleSlots).values(rows).returning();
+  }
+
+  async getSlot(id: number): Promise<ScheduleSlot | undefined> {
+    const [slot] = await db.select().from(scheduleSlots).where(eq(scheduleSlots.id, id));
+    return slot || undefined;
+  }
+
+  async getSlotsBetween(start: Date, end: Date): Promise<ScheduleSlot[]> {
+    return await db
+      .select()
+      .from(scheduleSlots)
+      .where(and(gte(scheduleSlots.startTime, start), lt(scheduleSlots.startTime, end)))
+      .orderBy(scheduleSlots.startTime);
+  }
+
+  async deleteSlot(id: number): Promise<void> {
+    await db.delete(slotRegistrations).where(eq(slotRegistrations.slotId, id));
+    await db.delete(scheduleSlots).where(eq(scheduleSlots.id, id));
+  }
+
+  async deleteSeriesFrom(seriesId: string, fromTime: Date): Promise<void> {
+    const slots = await this.getFutureSlotsInSeries(seriesId, fromTime);
+    const ids = slots.map((s) => s.id);
+    if (ids.length === 0) return;
+    await db.delete(slotRegistrations).where(inArray(slotRegistrations.slotId, ids));
+    await db.delete(scheduleSlots).where(inArray(scheduleSlots.id, ids));
+  }
+
+  async getFutureSlotsInSeries(seriesId: string, fromTime: Date): Promise<ScheduleSlot[]> {
+    return await db
+      .select()
+      .from(scheduleSlots)
+      .where(and(eq(scheduleSlots.seriesId, seriesId), gte(scheduleSlots.startTime, fromTime)))
+      .orderBy(scheduleSlots.startTime);
+  }
+
+  async getSlotRegistrationCounts(slotIds: number[]): Promise<Map<number, number>> {
+    const counts = new Map<number, number>();
+    if (slotIds.length === 0) return counts;
+    const rows = await db
+      .select({
+        slotId: slotRegistrations.slotId,
+        count: sql<number>`cast(count(*) as int)`,
+      })
+      .from(slotRegistrations)
+      .where(inArray(slotRegistrations.slotId, slotIds))
+      .groupBy(slotRegistrations.slotId);
+    for (const row of rows) counts.set(row.slotId, row.count);
+    return counts;
+  }
+
+  async getUserRegisteredSlotIds(slotIds: number[], userId: string): Promise<Set<number>> {
+    const result = new Set<number>();
+    if (slotIds.length === 0) return result;
+    const rows = await db
+      .select({ slotId: slotRegistrations.slotId })
+      .from(slotRegistrations)
+      .where(and(inArray(slotRegistrations.slotId, slotIds), eq(slotRegistrations.driverId, userId)));
+    for (const row of rows) result.add(row.slotId);
+    return result;
+  }
+
+  async getSlotRegistrations(
+    slotId: number,
+  ): Promise<(SlotRegistration & { username: string; section: string; phoneNumber: string | null })[]> {
+    return await db
+      .select({
+        id: slotRegistrations.id,
+        slotId: slotRegistrations.slotId,
+        driverId: slotRegistrations.driverId,
+        createdAt: slotRegistrations.createdAt,
+        username: users.username,
+        section: users.section,
+        phoneNumber: users.phoneNumber,
+      })
+      .from(slotRegistrations)
+      .innerJoin(users, eq(slotRegistrations.driverId, users.id))
+      .where(eq(slotRegistrations.slotId, slotId))
+      .orderBy(slotRegistrations.createdAt);
+  }
+
+  async registerForSlot(slotId: number, driverId: string): Promise<void> {
+    const existing = await db
+      .select({ id: slotRegistrations.id })
+      .from(slotRegistrations)
+      .where(and(eq(slotRegistrations.slotId, slotId), eq(slotRegistrations.driverId, driverId)));
+    if (existing.length > 0) return; // already registered — no-op
+    await db.insert(slotRegistrations).values({ slotId, driverId });
+  }
+
+  async unregisterFromSlot(slotId: number, driverId: string): Promise<void> {
+    await db
+      .delete(slotRegistrations)
+      .where(and(eq(slotRegistrations.slotId, slotId), eq(slotRegistrations.driverId, driverId)));
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -85,6 +85,29 @@ export const sessions = pgTable("session", {
   expire: timestamp("expire").notNull(),
 });
 
+// Scheduling board: admin-declared recurring journey demand ("slots").
+// Each row is one concrete occurrence; recurring occurrences share a seriesId.
+export const scheduleSlots = pgTable("schedule_slots", {
+  id: serial("id").primaryKey(),
+  seriesId: varchar("series_id"), // null = one-off; shared across recurring occurrences
+  destination: text("destination").notNull(),
+  startTime: timestamp("start_time").notNull(), // UTC
+  endTime: timestamp("end_time").notNull(), // UTC (gives the event its duration/height)
+  driversNeeded: integer("drivers_needed").notNull(),
+  notes: text("notes"),
+  createdBy: varchar("created_by").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// A driver's pledge to drive for a specific slot occurrence.
+export const slotRegistrations = pgTable("slot_registrations", {
+  id: serial("id").primaryKey(),
+  slotId: integer("slot_id").notNull(),
+  driverId: varchar("driver_id").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 // Relations
 export const usersRelations = relations(users, ({ many }) => ({
   trips: many(trips),
@@ -144,6 +167,25 @@ export const notificationsRelations = relations(notifications, ({ one }) => ({
   }),
 }));
 
+export const scheduleSlotsRelations = relations(scheduleSlots, ({ one, many }) => ({
+  creator: one(users, {
+    fields: [scheduleSlots.createdBy],
+    references: [users.id],
+  }),
+  registrations: many(slotRegistrations),
+}));
+
+export const slotRegistrationsRelations = relations(slotRegistrations, ({ one }) => ({
+  slot: one(scheduleSlots, {
+    fields: [slotRegistrations.slotId],
+    references: [scheduleSlots.id],
+  }),
+  driver: one(users, {
+    fields: [slotRegistrations.driverId],
+    references: [users.id],
+  }),
+}));
+
 // Insert schemas
 export const insertTripSchema = createInsertSchema(trips).omit({
   id: true,
@@ -183,6 +225,33 @@ export const insertNotificationSchema = createInsertSchema(notifications).omit({
   createdAt: true,
 });
 
+export const insertScheduleSlotSchema = createInsertSchema(scheduleSlots).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+// API request schema for creating slots (admin). Accepts a start time + duration
+// plus optional weekly recurrence; the server expands this into occurrence rows.
+export const createSlotRequestSchema = z.object({
+  destination: z.string().min(1),
+  startTime: z.string(), // ISO datetime, interpreted as GMT+3 on the server
+  durationMinutes: z.number().int().positive().max(24 * 60),
+  driversNeeded: z.number().int().positive(),
+  notes: z.string().optional(),
+  recurrence: z
+    .object({
+      daysOfWeek: z.array(z.number().int().min(0).max(6)).min(1), // 0=Sun..6=Sat
+      endDate: z.string(), // ISO date; recurrence runs through this date inclusive
+    })
+    .optional(),
+});
+
+export const insertSlotRegistrationSchema = createInsertSchema(slotRegistrations).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Types
 export type User = typeof users.$inferSelect;
 export type InsertUser = typeof users.$inferInsert;
@@ -197,3 +266,8 @@ export type InsertTripJoinRequest = z.infer<typeof insertTripJoinRequestSchema>;
 export type Notification = typeof notifications.$inferSelect;
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;
 export type UserRole = typeof userRoles[number];
+export type ScheduleSlot = typeof scheduleSlots.$inferSelect;
+export type InsertScheduleSlot = z.infer<typeof insertScheduleSlotSchema>;
+export type CreateSlotRequest = z.infer<typeof createSlotRequestSchema>;
+export type SlotRegistration = typeof slotRegistrations.$inferSelect;
+export type InsertSlotRegistration = z.infer<typeof insertSlotRegistrationSchema>;


### PR DESCRIPTION
Admins declare recurring car demand on a Google-Calendar-style weekly view (destination, duration, drivers needed, optional weekly recurrence); any authenticated user can pledge to drive a slot, optionally repeating weekly. Each event shows registered/needed and updates live over WebSocket.

- schema: schedule_slots + slot_registrations tables, relations, types
- storage: slot CRUD, registration counts, register/unregister
- routes: /api/schedule/* with timezone-aware recurrence expansion
- client: SchedulePage calendar (now the home page), SlotFormDialog, SlotDetailsDialog; dashboard moved to /dashboard; nav + realtime wired