### PR TITLE
Fix slow dashboard load by batching user lookups

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -61,19 +61,8 @@ export default function Dashboard() {
   const [sortBy, setSortBy] = useState("departure_time");
   const [activeTab, setActiveTab] = useState("all-trips");
 
-  // Effect to refresh data when switching tabs
-  useEffect(() => {
-    // Force refresh of queries when switching tabs to ensure fresh data
-    const timeoutId = setTimeout(() => {
-      if (activeTab === "all-trips") {
-        queryClient.invalidateQueries({ queryKey: ["/api/trips"] });
-      } else if (activeTab === "my-trips") {
-        queryClient.invalidateQueries({ queryKey: ["/api/trips/my"] });
-      }
-    }, 100); // Small delay to ensure tab switch is complete
-    
-    return () => clearTimeout(timeoutId);
-  }, [activeTab, queryClient]);
+  // Trips data is kept fresh via refetchOnWindowFocus plus a short staleTime,
+  // so switching tabs reuses the cache instead of forcing a blocking refetch.
 
   // Function to get today's trip range (5 AM today to 4 AM tomorrow)
   const getTodayTripRange = () => {
@@ -102,7 +91,7 @@ export default function Dashboard() {
     queryFn: () =>
       fetch(`/api/trips`).then((res) => res.json()),
     refetchOnWindowFocus: true,
-    staleTime: 0, // Always consider data stale
+    staleTime: 30_000, // Reuse cached data for 30s to avoid blocking refetches
   });
 
   // Filter trips to show only today's trips (5 AM to 4 AM next day)
@@ -117,7 +106,7 @@ export default function Dashboard() {
     queryKey: ["/api/trips/my"],
     enabled: user?.role !== "admin", // Don't fetch my trips for admin users
     refetchOnWindowFocus: true,
-    staleTime: 0, // Always consider data stale
+    staleTime: 30_000, // Reuse cached data for 30s to avoid blocking refetches
   });
 
   // Filter my trips to show only today's trips using the same logic as "All Trips"

--- a/server/new-routes.ts
+++ b/server/new-routes.ts
@@ -14,6 +14,7 @@ import {
   insertTripJoinRequestSchema,
   createSlotRequestSchema,
   type CreateSlotRequest,
+  type User,
 } from "@shared/schema";
 import { z } from "zod";
 import TelegramBot from "node-telegram-bot-api";
@@ -445,6 +446,17 @@ const isAdmin = (req: any, res: any, next: any) => {
   return res.status(403).json({ message: "Forbidden: Admins only" });
 };
 
+// Strip a User down to the public fields exposed in API responses.
+function toPublicUser(user: User) {
+  return {
+    id: user.id,
+    username: user.username,
+    section: user.section,
+    role: user.role,
+    phoneNumber: user.phoneNumber,
+  };
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
   const server = createServer(app);
 
@@ -578,42 +590,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const trips = await storage.getAllTrips();
 
-      const tripsWithDetails = await Promise.all(
-        trips.map(async (trip) => {
-          // Get rider details from the riders array in the trip
-          const riderDetails = await Promise.all(
-            (trip.riders || []).map(async (riderId) => {
-              const user = await storage.getUser(riderId);
-              return user
-                ? {
-                    id: user.id,
-                    username: user.username,
-                    section: user.section,
-                    role: user.role,
-                    phoneNumber: user.phoneNumber,
-                  }
-                : null;
-            }),
-          );
+      // Batch-fetch every driver/rider user in one query to avoid N+1 lookups.
+      const userIds = trips.flatMap((trip) => [
+        trip.driverId,
+        ...(trip.riders || []),
+      ]);
+      const userMap = await storage.getUsersByIds(userIds);
 
-          const driver = await storage.getUser(trip.driverId);
+      const tripsWithDetails = trips.map((trip) => {
+        const riderDetails = (trip.riders || [])
+          .map((riderId) => userMap.get(riderId))
+          .filter(Boolean)
+          .map((user) => toPublicUser(user!));
 
-          return {
-            ...trip,
-            participantCount: trip.riders?.length || 0,
-            riderDetails: riderDetails.filter(Boolean),
-            driver: driver
-              ? {
-                  id: driver.id,
-                  username: driver.username,
-                  section: driver.section,
-                  role: driver.role,
-                  phoneNumber: driver.phoneNumber,
-                }
-              : null,
-          };
-        }),
-      );
+        const driver = userMap.get(trip.driverId);
+
+        return {
+          ...trip,
+          participantCount: trip.riders?.length || 0,
+          riderDetails,
+          driver: driver ? toPublicUser(driver) : null,
+        };
+      });
 
       res.json(tripsWithDetails);
     } catch (error) {
@@ -627,42 +625,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const userId = req.user.id;
       const trips = await storage.getUserTrips(userId);
 
-      const tripsWithDetails = await Promise.all(
-        trips.map(async (trip) => {
-          // Get rider details from the riders array in the trip
-          const riderDetails = await Promise.all(
-            (trip.riders || []).map(async (riderId) => {
-              const user = await storage.getUser(riderId);
-              return user
-                ? {
-                    id: user.id,
-                    username: user.username,
-                    section: user.section,
-                    role: user.role,
-                    phoneNumber: user.phoneNumber,
-                  }
-                : null;
-            }),
-          );
+      // Batch-fetch every driver/rider user in one query to avoid N+1 lookups.
+      const userIds = trips.flatMap((trip) => [
+        trip.driverId,
+        ...(trip.riders || []),
+      ]);
+      const userMap = await storage.getUsersByIds(userIds);
 
-          const driver = await storage.getUser(trip.driverId);
+      const tripsWithDetails = trips.map((trip) => {
+        const riderDetails = (trip.riders || [])
+          .map((riderId) => userMap.get(riderId))
+          .filter(Boolean)
+          .map((user) => toPublicUser(user!));
 
-          return {
-            ...trip,
-            participantCount: trip.riders?.length || 0,
-            riderDetails: riderDetails.filter(Boolean),
-            driver: driver
-              ? {
-                  id: driver.id,
-                  username: driver.username,
-                  section: driver.section,
-                  role: driver.role,
-                  phoneNumber: driver.phoneNumber,
-                }
-              : null,
-          };
-        }),
-      );
+        const driver = userMap.get(trip.driverId);
+
+        return {
+          ...trip,
+          participantCount: trip.riders?.length || 0,
+          riderDetails,
+          driver: driver ? toPublicUser(driver) : null,
+        };
+      });
 
       res.json(tripsWithDetails);
     } catch (error) {
@@ -964,24 +948,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.log("User authenticated:", req.session?.userId || req.user?.id);
       console.log("Found requests:", requests.length);
 
-      // Enrich with rider info
-      const enrichedRequests = await Promise.all(
-        requests.map(async (request) => {
-          const rider = await storage.getUser(request.riderId);
-          return {
-            ...request,
-            rider: rider
-              ? {
-                  id: rider.id,
-                  username: rider.username,
-                  section: rider.section,
-                  role: rider.role,
-                  phoneNumber: rider.phoneNumber,
-                }
-              : null,
-          };
-        }),
+      // Enrich with rider info, batch-fetching all riders in one query.
+      const riderMap = await storage.getUsersByIds(
+        requests.map((request) => request.riderId),
       );
+      const enrichedRequests = requests.map((request) => {
+        const rider = riderMap.get(request.riderId);
+        return {
+          ...request,
+          rider: rider ? toPublicUser(rider) : null,
+        };
+      });
 
       console.log("Returning", enrichedRequests.length, "enriched requests");
       

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -31,6 +31,7 @@ import { nowGMTPlus3, getTodayRangeUTC, fromGMTPlus3ToUTC } from "@shared/timezo
 export interface IStorage {
   // User operations
   getUser(id: string): Promise<User | undefined>;
+  getUsersByIds(ids: (string | null | undefined)[]): Promise<Map<string, User>>;
   getUserByUsernameAndSection(username: string, section: string): Promise<User | undefined>;
   upsertUser(user: InsertUser): Promise<User>;
   updateUser(id: string, updates: Partial<InsertUser>): Promise<User>;
@@ -173,6 +174,15 @@ export class DatabaseStorage implements IStorage {
   async getUser(id: string): Promise<User | undefined> {
     const [user] = await db.select().from(users).where(eq(users.id, id));
     return user || undefined;
+  }
+
+  // Batch-fetch users by id in a single query, returned as an id->user map.
+  // Avoids the N+1 query pattern when enriching lists of trips/requests.
+  async getUsersByIds(ids: (string | null | undefined)[]): Promise<Map<string, User>> {
+    const uniqueIds = Array.from(new Set(ids.filter((id): id is string => Boolean(id))));
+    if (uniqueIds.length === 0) return new Map();
+    const rows = await db.select().from(users).where(inArray(users.id, uniqueIds));
+    return new Map(rows.map((u) => [u.id, u]));
   }
 
   async getUserByUsernameAndSection(username: string, section: string): Promise<User | undefined> {


### PR DESCRIPTION
The dashboard's /api/trips, /api/trips/my, and /api/ride-requests/all endpoints fetched the driver and each rider with a separate getUser() call, producing an N+1 query storm on every load. Add a batched getUsersByIds() and use it to resolve all users in a single query.

Also relax the dashboard's react-query config (staleTime 0 -> 30s and drop the force-invalidate on tab switch) so navigating back reuses the cache instead of blocking on a full-screen "Loading..." refetch.