### PR TITLE
Make server crash-resistant so one bad request can't down the dashboard

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,17 @@ import { setupVite, serveStatic, log } from "./vite";
 import dotenv from "dotenv";
 dotenv.config();
 
+// Keep the process alive when a single request or background task fails.
+// Without these guards (and with no process manager to restart us), one
+// unhandled error takes the entire server down — making every page, including
+// the dashboard, "break immediately" until a manual restart.
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled promise rejection:", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("Uncaught exception:", err);
+});
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
@@ -45,8 +56,12 @@ app.use((req, res, next) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
-    res.status(status).json({ message });
-    throw err;
+    console.error("Unhandled request error:", err);
+    // Respond once; do NOT re-throw. Re-throwing here aborts the response and,
+    // for async errors, can take down the whole process.
+    if (!res.headersSent) {
+      res.status(status).json({ message });
+    }
   });
 
   // importantly only setup vite in development and after

--- a/server/new-routes.ts
+++ b/server/new-routes.ts
@@ -37,9 +37,14 @@ const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
 function broadcastToAll(data: any) {
   const message = JSON.stringify(data);
   connectedClients.forEach((ws: any) => {
-    if (ws.readyState === 1) {
-      // WebSocket.OPEN
+    if (ws.readyState !== 1) return; // not OPEN
+    try {
       ws.send(message);
+    } catch (error) {
+      // A socket can die between the readyState check and send(); drop it
+      // rather than letting the throw bubble up and fail the request.
+      console.error("Failed to send WebSocket message, dropping client:", error);
+      connectedClients.delete(ws);
     }
   });
 }


### PR DESCRIPTION
There is no process manager or auto-restart (dev runs `tsx server/index.ts`, prod runs plain `node`), so any crash takes the whole site down until a manual restart — which is why the dashboard intermittently "breaks immediately" rather than just loading slowly.

- Add process-level unhandledRejection/uncaughtException handlers that log instead of letting Node terminate. Express 4 does not catch async route rejections, so without these a single failing request killed the process.
- Stop the global error handler from re-throwing after it has already sent a response; that aborted the response and could surface as an unhandled error.
- Guard ws.send() in broadcastToAll so a socket dying between the readyState check and send (common around the new schedule broadcasts) can't bubble up and fail the request.