### PR TITLE
Show only today's trips in Telegram /info command

### DIFF
--- a/server/telegram.ts
+++ b/server/telegram.ts
@@ -377,10 +377,10 @@ class TelegramNotificationService {
   }
 
   private async buildTripListText(returnOnly: boolean): Promise<string> {
-    const allTrips = await storage.getAllTrips();
-    const filtered = allTrips.filter((t) => t.isReturnTrip === returnOnly);
+    const todayTrips = await storage.getTodayTrips();
+    const filtered = todayTrips.filter((t) => t.isReturnTrip === returnOnly);
 
-    if (filtered.length === 0) return "لا توجد رحلات حالياً.";
+    if (filtered.length === 0) return "لا توجد رحلات اليوم.";
 
     const driverIds = filtered.map((t) => t.driverId);
     const driverMap = await storage.getUsersByIds(driverIds);


### PR DESCRIPTION
buildTripListText used getAllTrips(), listing every trip ever created. Switch to getTodayTrips() so the bot's trip browser matches the website, filtering to the app's custom day (5 AM GMT+3 boundary).